### PR TITLE
Add VAE training pipeline with topological loss support

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,14 @@
+"""Model architectures and losses for topology-regularised generative models."""
+
+try:
+    from .vae import MolecularVAE, vae_loss
+except ModuleNotFoundError:
+    MolecularVAE = None  # type: ignore
+    vae_loss = None  # type: ignore
+
+try:
+    from .topo_loss import TopologicalLoss
+except ModuleNotFoundError:
+    TopologicalLoss = None  # type: ignore
+
+__all__ = ["MolecularVAE", "vae_loss", "TopologicalLoss"]

--- a/src/models/topo_loss.py
+++ b/src/models/topo_loss.py
@@ -1,0 +1,208 @@
+"""Topological regularisation module for molecular generative models."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor, nn
+
+from src.tda.persistence import DiagramBatch, compute_persistence_diagrams
+from src.tda.pd_metrics import wasserstein_distance
+
+
+def _to_numpy(batch: Tensor | np.ndarray) -> np.ndarray:
+    if isinstance(batch, torch.Tensor):
+        return batch.detach().cpu().numpy()
+    return np.asarray(batch)
+
+
+@dataclass
+class TopologicalLossState:
+    """Container tracking cached loss statistics."""
+
+    step: Optional[int] = None
+    value: Optional[float] = None
+    per_dimension: MutableMapping[int, float] | None = None
+
+
+class TopologicalLoss(nn.Module):
+    """Compute a Wasserstein-based topological loss between two batches.
+
+    The module caches the expensive persistent homology computation and only
+    recomputes it every ``update_every`` calls. ``forward`` returns a scalar
+    ``Tensor`` that can be combined with other loss terms. The returned tensor
+    does **not** carry gradients with respect to the input coordinates because
+    persistent homology is non-differentiable for general point clouds. This is
+    intentional – the tensor is safe to use within autograd graphs without
+    leaking resources, but gradients will be zero. Future differentiable
+    relaxations can be plugged in by overriding :meth:`_compute_distance`.
+    """
+
+    def __init__(
+        self,
+        homology_dims: Sequence[int] = (1,),
+        max_edge_length: Optional[float] = None,
+        backend: str = "auto",
+        center: bool = True,
+        update_every: int = 1,
+        reduction: str = "mean",
+        dim_weights: Optional[Mapping[int, float]] = None,
+        wasserstein_kwargs: Optional[Mapping[str, float | str]] = None,
+    ) -> None:
+        super().__init__()
+        if len(homology_dims) == 0:
+            raise ValueError("At least one homology dimension must be specified.")
+        self.homology_dims: Tuple[int, ...] = tuple(sorted(set(int(dim) for dim in homology_dims)))
+        self.max_edge_length = max_edge_length
+        self.backend = backend
+        self.center = center
+        self.update_every = max(1, int(update_every))
+        if reduction not in {"mean", "sum"}:
+            raise ValueError("reduction must be 'mean' or 'sum'.")
+        self.reduction = reduction
+        if dim_weights is None:
+            self.dim_weights = {dim: 1.0 for dim in self.homology_dims}
+        else:
+            self.dim_weights = {int(k): float(v) for k, v in dim_weights.items()}
+        self.wasserstein_kwargs: Dict[str, float | str] = {
+            "order": 2.0,
+            "method": "auto",
+            "epsilon": 5e-3,
+            "max_iterations": 1000,
+            "tolerance": 1e-6,
+        }
+        if wasserstein_kwargs:
+            self.wasserstein_kwargs.update(wasserstein_kwargs)
+
+        self._state = TopologicalLossState()
+        self._reference: Optional[DiagramBatch] = None
+
+    @property
+    def last_step(self) -> Optional[int]:
+        return self._state.step
+
+    @property
+    def last_value(self) -> Optional[float]:
+        return self._state.value
+
+    @property
+    def last_per_dimension(self) -> Optional[Mapping[int, float]]:
+        return self._state.per_dimension
+
+    def reset(self) -> None:
+        """Clear cached values forcing the next call to recompute diagrams."""
+
+        self._state = TopologicalLossState()
+
+    def set_reference(self, diagrams: DiagramBatch) -> None:
+        """Provide pre-computed reference diagrams for the real batch.
+
+        When a reference is set the ``real_batch`` passed to :meth:`forward`
+        can be ``None``. This is useful for large datasets where the real
+        diagrams are computed offline once.
+        """
+
+        self._reference = diagrams
+
+    def forward(
+        self,
+        real_batch: Optional[Tensor | np.ndarray],
+        generated_batch: Tensor | np.ndarray,
+        *,
+        step: Optional[int] = None,
+        force: bool = False,
+    ) -> Tensor:
+        """Return the cached or freshly computed topological loss."""
+
+        device = generated_batch.device if isinstance(generated_batch, torch.Tensor) else None
+        dtype = generated_batch.dtype if isinstance(generated_batch, torch.Tensor) else None
+
+        reuse = (
+            not force
+            and self._state.value is not None
+            and self._state.step is not None
+            and step is not None
+            and (step - self._state.step) < self.update_every
+        )
+        if reuse:
+            return self._to_tensor(self._state.value, device=device, dtype=dtype)
+
+        if self._reference is None and real_batch is None:
+            raise ValueError("real_batch cannot be None unless a reference is set via set_reference().")
+
+        with torch.no_grad():
+            real_diagrams = self._reference
+            if real_diagrams is None:
+                real_np = _to_numpy(real_batch)  # type: ignore[arg-type]
+                real_diagrams = compute_persistence_diagrams(
+                    real_np,
+                    homology_dims=self.homology_dims,
+                    max_edge_length=self.max_edge_length,
+                    backend=self.backend,
+                    center=self.center,
+                )
+            gen_np = _to_numpy(generated_batch)
+            gen_diagrams = compute_persistence_diagrams(
+                gen_np,
+                homology_dims=self.homology_dims,
+                max_edge_length=self.max_edge_length,
+                backend=self.backend,
+                center=self.center,
+            )
+
+            value, per_dim = self._evaluate(real_diagrams, gen_diagrams)
+
+        self._state = TopologicalLossState(step=step, value=value, per_dimension=per_dim)
+        return self._to_tensor(value, device=device, dtype=dtype)
+
+    def _evaluate(self, real: DiagramBatch, generated: DiagramBatch) -> Tuple[float, MutableMapping[int, float]]:
+        if len(real.diagrams) == 0 or len(generated.diagrams) == 0:
+            return 0.0, {dim: 0.0 for dim in self.homology_dims}
+
+        batch = min(len(real.diagrams), len(generated.diagrams))
+        dim_accumulator: Dict[int, list[float]] = {dim: [] for dim in self.homology_dims}
+
+        for idx in range(batch):
+            real_diagram = real.diagrams[idx]
+            gen_diagram = generated.diagrams[idx]
+            for dim in self.homology_dims:
+                dist = self._compute_distance(
+                    real_diagram.get(dim, np.empty((0, 2))),
+                    gen_diagram.get(dim, np.empty((0, 2))),
+                )
+                dim_accumulator[dim].append(float(dist))
+
+        per_dimension = {
+            dim: float(np.mean(values)) if len(values) > 0 else 0.0
+            for dim, values in dim_accumulator.items()
+        }
+
+        total_weight = sum(self.dim_weights.get(dim, 0.0) for dim in self.homology_dims)
+        if math.isclose(total_weight, 0.0):
+            total_weight = float(len(self.homology_dims))
+        if self.reduction == "mean":
+            weighted = sum(self.dim_weights.get(dim, 1.0) * per_dimension[dim] for dim in self.homology_dims)
+            loss_value = weighted / max(total_weight, 1e-12)
+        else:  # sum
+            loss_value = sum(self.dim_weights.get(dim, 1.0) * per_dimension[dim] for dim in self.homology_dims)
+
+        return float(loss_value), per_dimension
+
+    def _compute_distance(self, diag_real: np.ndarray, diag_gen: np.ndarray) -> float:
+        return float(wasserstein_distance(diag_real, diag_gen, **self.wasserstein_kwargs))
+
+    @staticmethod
+    def _to_tensor(value: float, device: Optional[torch.device], dtype: Optional[torch.dtype]) -> Tensor:
+        if dtype is None:
+            tensor = torch.tensor(value)
+        else:
+            tensor = torch.tensor(value, dtype=dtype)
+        if device is not None:
+            tensor = tensor.to(device)
+        return tensor
+
+
+__all__ = ["TopologicalLoss", "TopologicalLossState"]

--- a/src/models/vae.py
+++ b/src/models/vae.py
@@ -1,0 +1,178 @@
+"""Variational auto-encoder tailored for molecular conformations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import torch
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+
+@dataclass
+class VAEOutput:
+    """Bundle the outputs of a forward VAE pass."""
+
+    reconstruction: Tensor
+    mean: Tensor
+    logvar: Tensor
+
+
+def _build_mlp(input_dim: int, hidden_dims: Sequence[int], output_dim: int) -> nn.Sequential:
+    layers: List[nn.Module] = []
+    current = input_dim
+    for width in hidden_dims:
+        layers.append(nn.Linear(current, width))
+        layers.append(nn.ReLU())
+        current = width
+    layers.append(nn.Linear(current, output_dim))
+    return nn.Sequential(*layers)
+
+
+class MolecularVAE(nn.Module):
+    """Simple coordinate-space VAE with optional geometric constraints."""
+
+    def __init__(
+        self,
+        n_atoms: int,
+        latent_dim: int = 8,
+        hidden_dims: Sequence[int] = (256, 128, 64),
+        enforce_constraints: bool = False,
+        bond_indices: Optional[Sequence[Tuple[int, int]]] = None,
+        target_bond_lengths: Optional[Sequence[float]] = None,
+        coordinate_scaling: float = 1.0,
+    ) -> None:
+        super().__init__()
+        if n_atoms <= 0:
+            raise ValueError("n_atoms must be positive.")
+        if latent_dim <= 0:
+            raise ValueError("latent_dim must be positive.")
+        self.n_atoms = int(n_atoms)
+        self.latent_dim = int(latent_dim)
+        self.input_dim = self.n_atoms * 3
+        self.enforce_constraints = enforce_constraints
+        self.coordinate_scaling = float(coordinate_scaling)
+
+        self.encoder = _build_mlp(self.input_dim, hidden_dims, 2 * self.latent_dim)
+        decoder_hidden = tuple(reversed(tuple(hidden_dims)))
+        self.decoder = _build_mlp(self.latent_dim, decoder_hidden, self.input_dim)
+
+        if enforce_constraints:
+            if bond_indices is None or target_bond_lengths is None:
+                raise ValueError("Constraint enforcement requires bond indices and target lengths.")
+            if len(bond_indices) != len(target_bond_lengths):
+                raise ValueError("bond_indices and target_bond_lengths must have equal length.")
+            self.register_buffer(
+                "bond_indices",
+                torch.tensor(bond_indices, dtype=torch.long),
+            )
+            self.register_buffer(
+                "target_bond_lengths",
+                torch.tensor(target_bond_lengths, dtype=torch.get_default_dtype()),
+            )
+        else:
+            self.register_buffer("bond_indices", torch.empty((0, 2), dtype=torch.long))
+            self.register_buffer("target_bond_lengths", torch.empty((0,), dtype=torch.get_default_dtype()))
+
+    def encode(self, x: Tensor) -> Tuple[Tensor, Tensor]:
+        flat = self._flatten(x)
+        encoded = self.encoder(flat)
+        mu, logvar = encoded[:, : self.latent_dim], encoded[:, self.latent_dim :]
+        return mu, logvar
+
+    def reparameterize(self, mu: Tensor, logvar: Tensor) -> Tensor:
+        std = torch.exp(0.5 * logvar)
+        eps = torch.randn_like(std)
+        return mu + eps * std
+
+    def decode(self, z: Tensor) -> Tensor:
+        flat = self.decoder(z)
+        coords = flat.view(z.shape[0], self.n_atoms, 3)
+        if not math.isclose(self.coordinate_scaling, 1.0, rel_tol=1e-6, abs_tol=1e-9):
+            coords = coords * self.coordinate_scaling
+        return coords
+
+    def forward(self, x: Tensor) -> VAEOutput:
+        mu, logvar = self.encode(x)
+        z = self.reparameterize(mu, logvar)
+        recon = self.decode(z)
+        return VAEOutput(reconstruction=recon, mean=mu, logvar=logvar)
+
+    def sample(self, num_samples: int, device: Optional[torch.device] = None) -> Tensor:
+        if num_samples <= 0:
+            raise ValueError("num_samples must be positive.")
+        device = device or next(self.parameters()).device
+        z = torch.randn((num_samples, self.latent_dim), device=device)
+        with torch.no_grad():
+            samples = self.decode(z)
+        return samples
+
+    def constraint_loss(self, coords: Tensor) -> Tensor:
+        if not self.enforce_constraints or self.bond_indices.numel() == 0:
+            return coords.new_zeros(())
+        pi = coords[:, self.bond_indices[:, 0]]
+        pj = coords[:, self.bond_indices[:, 1]]
+        distances = torch.linalg.norm(pi - pj, dim=-1)
+        target = self.target_bond_lengths.unsqueeze(0).expand_as(distances)
+        loss = F.mse_loss(distances, target)
+        return loss
+
+    def _flatten(self, x: Tensor) -> Tensor:
+        if x.ndim != 3 or x.shape[1] != self.n_atoms or x.shape[2] != 3:
+            raise ValueError(
+                f"Input must have shape (batch, {self.n_atoms}, 3); received {tuple(x.shape)}."
+            )
+        centered = x - x.mean(dim=1, keepdim=True)
+        return centered.view(x.shape[0], -1)
+
+
+def vae_loss(
+    output: VAEOutput,
+    inputs: Tensor,
+    *,
+    beta: float = 1.0,
+    topo_term: Optional[Tensor] = None,
+    topo_weight: float = 1.0,
+    constraint_term: Optional[Tensor] = None,
+    constraint_weight: float = 1.0,
+    reduction: str = "mean",
+) -> Dict[str, Tensor]:
+    """Assemble the VAE objective and optional regularisers."""
+
+    if reduction not in {"mean", "sum"}:
+        raise ValueError("reduction must be 'mean' or 'sum'.")
+
+    if reduction == "mean":
+        recon = F.mse_loss(output.reconstruction, inputs, reduction="mean")
+    else:
+        recon = F.mse_loss(output.reconstruction, inputs, reduction="sum")
+
+    kl = -0.5 * torch.sum(1 + output.logvar - output.mean.pow(2) - output.logvar.exp(), dim=1)
+    if reduction == "mean":
+        kl = kl.mean()
+    else:
+        kl = kl.sum()
+
+    total = recon + beta * kl
+
+    topo = torch.zeros_like(total)
+    if topo_term is not None:
+        topo = topo_term if topo_term.ndim == 0 else topo_term.squeeze()
+        total = total + topo_weight * topo
+
+    constraint = torch.zeros_like(total)
+    if constraint_term is not None:
+        constraint = constraint_term if constraint_term.ndim == 0 else constraint_term.squeeze()
+        total = total + constraint_weight * constraint
+
+    return {
+        "loss": total,
+        "reconstruction": recon.detach(),
+        "kl": kl.detach(),
+        "topology": topo.detach(),
+        "constraint": constraint.detach(),
+    }
+
+
+__all__ = ["MolecularVAE", "VAEOutput", "vae_loss"]

--- a/src/train/__init__.py
+++ b/src/train/__init__.py
@@ -1,0 +1,13 @@
+"""Training and evaluation entrypoints for topology-aware generative models."""
+
+try:
+    from .train_vae import main as train_vae_main
+except ModuleNotFoundError:
+    train_vae_main = None  # type: ignore
+
+try:
+    from .eval_topology import main as eval_topology_main
+except ModuleNotFoundError:
+    eval_topology_main = None  # type: ignore
+
+__all__ = ["train_vae_main", "eval_topology_main"]

--- a/src/train/eval_topology.py
+++ b/src/train/eval_topology.py
@@ -1,0 +1,152 @@
+"""Evaluate topological metrics for a trained molecular VAE."""
+from __future__ import annotations
+
+import argparse
+import json
+import copy
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from src.models.vae import MolecularVAE
+from src.tda.persistence import compute_persistence_diagrams
+from src.tda.pd_metrics import bottleneck_distance, wasserstein_distance
+from .train_vae import deep_update, load_config
+
+
+def _prepare_output_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _load_dataset(config: Mapping[str, Any]) -> np.ndarray:
+    dataset_cfg = config["dataset"]
+    array = np.load(dataset_cfg["path"])
+    return array
+
+
+def _load_model(checkpoint_path: Path, device: torch.device) -> tuple[MolecularVAE, Dict[str, Any]]:
+    checkpoint = torch.load(checkpoint_path, map_location=device)
+    config = checkpoint["config"]
+    model_cfg = config["model"]
+    model = MolecularVAE(**model_cfg)
+    model.load_state_dict(checkpoint["model_state"])
+    model.to(device)
+    model.eval()
+    return model, config
+
+
+def _compute_metrics(real_diagrams, gen_diagrams, homology_dims) -> Dict[str, float]:
+    metrics: Dict[str, float] = {}
+    batch = min(len(real_diagrams.diagrams), len(gen_diagrams.diagrams))
+    for dim in homology_dims:
+        wasserstein_values = []
+        bottleneck_values = []
+        for idx in range(batch):
+            real_diag = real_diagrams.diagrams[idx].get(dim, np.empty((0, 2)))
+            gen_diag = gen_diagrams.diagrams[idx].get(dim, np.empty((0, 2)))
+            wasserstein_values.append(float(wasserstein_distance(real_diag, gen_diag)))
+            bottleneck_values.append(float(bottleneck_distance(real_diag, gen_diag)))
+        if wasserstein_values:
+            metrics[f"wasserstein/h{dim}"] = float(np.mean(wasserstein_values))
+            metrics[f"bottleneck/h{dim}"] = float(np.mean(bottleneck_values))
+        else:
+            metrics[f"wasserstein/h{dim}"] = 0.0
+            metrics[f"bottleneck/h{dim}"] = 0.0
+    return metrics
+
+
+def _plot_diagrams(diagrams, title: str, output_path: Path) -> None:
+    cols = len(diagrams.homology_dims)
+    fig, axes = plt.subplots(1, cols, figsize=(4 * cols, 4))
+    if cols == 1:
+        axes = [axes]
+    for ax, dim in zip(axes, diagrams.homology_dims):
+        ax.set_title(f"H_{dim} diagram")
+        ax.set_xlabel("Birth")
+        ax.set_ylabel("Death")
+        for diag in diagrams.by_dimension(dim):
+            if diag.size == 0:
+                continue
+            ax.scatter(diag[:, 0], diag[:, 1], s=12, alpha=0.6)
+        ax.plot([0, 1], [0, 1], color="black", linestyle="--", linewidth=0.8)
+    fig.suptitle(title)
+    fig.tight_layout()
+    fig.savefig(output_path)
+    plt.close(fig)
+
+
+def evaluate(
+    checkpoint: Path,
+    *,
+    config: Optional[Dict[str, Any]] = None,
+    num_samples: int = 128,
+    output_dir: Optional[Path] = None,
+    device: Optional[str] = None,
+) -> Dict[str, Any]:
+    device_obj = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+    model, checkpoint_config = _load_model(checkpoint, device_obj)
+    merged_config = copy.deepcopy(checkpoint_config)
+    if config is not None:
+        deep_update(merged_config, config)
+
+    array = _load_dataset(merged_config)
+    limit = min(len(array), num_samples)
+    real_batch = array[:limit]
+
+    with torch.no_grad():
+        samples = model.sample(limit, device=device_obj).cpu().numpy()
+
+    homology_dims = tuple(merged_config.get("topology", {}).get("homology_dims", (0, 1)))
+    max_edge = merged_config.get("topology", {}).get("max_edge_length")
+
+    real_diagrams = compute_persistence_diagrams(real_batch, homology_dims=homology_dims, max_edge_length=max_edge)
+    gen_diagrams = compute_persistence_diagrams(samples, homology_dims=homology_dims, max_edge_length=max_edge)
+
+    metrics = _compute_metrics(real_diagrams, gen_diagrams, homology_dims)
+
+    output_path = output_dir or Path("eval_outputs")
+    _prepare_output_dir(output_path)
+    (output_path / "figures").mkdir(exist_ok=True)
+
+    json_path = output_path / "metrics.json"
+    json_path.write_text(json.dumps(metrics, indent=2))
+
+    _plot_diagrams(real_diagrams, "Real persistence diagrams", output_path / "figures" / "real.png")
+    _plot_diagrams(gen_diagrams, "Generated persistence diagrams", output_path / "figures" / "generated.png")
+
+    return {
+        "metrics": metrics,
+        "real_diagrams": real_diagrams,
+        "generated_diagrams": gen_diagrams,
+        "output_dir": output_path,
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:  # pragma: no cover - CLI wrapper
+    parser = argparse.ArgumentParser(description="Evaluate topology of generated samples.")
+    parser.add_argument("checkpoint", type=str, help="Path to a trained model checkpoint.")
+    parser.add_argument("--config", type=str, default=None, help="Optional override config file (YAML/JSON).")
+    parser.add_argument("--num-samples", type=int, default=128, help="Number of samples to generate for evaluation.")
+    parser.add_argument("--output-dir", type=str, default="eval_outputs", help="Directory to store outputs.")
+    parser.add_argument("--device", type=str, default=None, help="Evaluation device (cpu or cuda).")
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> Dict[str, Any]:  # pragma: no cover - CLI wrapper
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    override_config = load_config(args.config) if args.config else None
+    result = evaluate(
+        Path(args.checkpoint),
+        config=override_config,
+        num_samples=args.num_samples,
+        output_dir=Path(args.output_dir),
+        device=args.device,
+    )
+    return result
+
+
+__all__ = ["evaluate", "main"]

--- a/src/train/train_vae.py
+++ b/src/train/train_vae.py
@@ -1,0 +1,396 @@
+"""Training loop for the molecular VAE with optional topological regularisation."""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor
+from torch.utils.data import DataLoader, Dataset, Subset
+
+from src.models.topo_loss import TopologicalLoss
+from src.models.vae import MolecularVAE, vae_loss
+
+try:  # Optional YAML support for configs
+    import yaml
+except Exception:  # pragma: no cover - yaml is optional
+    yaml = None  # type: ignore
+
+try:  # Optional TensorBoard logging
+    from torch.utils.tensorboard import SummaryWriter
+except Exception:  # pragma: no cover - TensorBoard is optional
+    SummaryWriter = None  # type: ignore
+
+try:  # Optional Weights & Biases logging
+    import wandb
+except Exception:  # pragma: no cover - WandB is optional
+    wandb = None  # type: ignore
+
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "dataset": {
+        "path": "data/synthetic_hexapeptide.npy",
+        "train_fraction": 0.7,
+        "val_fraction": 0.15,
+        "test_fraction": 0.15,
+        "seed": 123,
+    },
+    "model": {
+        "latent_dim": 8,
+        "hidden_dims": [256, 128, 64],
+        "enforce_constraints": False,
+        "coordinate_scaling": 1.0,
+    },
+    "training": {
+        "epochs": 5,
+        "batch_size": 64,
+        "learning_rate": 1e-3,
+        "weight_decay": 0.0,
+        "beta": 1.0,
+        "max_steps": None,
+        "log_every": 10,
+        "checkpoint_every": 100,
+        "output_dir": "runs/vae",
+        "seed": 42,
+        "device": "auto",
+    },
+    "topology": {
+        "enabled": True,
+        "weight": 1.0,
+        "homology_dims": [1],
+        "max_edge_length": 15.0,
+        "update_every": 10,
+        "backend": "auto",
+    },
+    "logging": {
+        "backend": "tensorboard",
+        "project": "topo-vae",
+        "entity": None,
+    },
+}
+
+
+@dataclass
+class TrainState:
+    epoch: int
+    step: int
+    best_loss: float
+
+
+class ConformationDataset(Dataset[Tensor]):
+    """Simple dataset wrapping a numpy array of conformations."""
+
+    def __init__(self, array: np.ndarray) -> None:
+        if array.ndim != 3 or array.shape[-1] != 3:
+            raise ValueError(
+                "Conformations must have shape (n_samples, n_atoms, 3)."
+            )
+        self.data = torch.as_tensor(array, dtype=torch.get_default_dtype())
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return self.data.shape[0]
+
+    def __getitem__(self, index: int) -> Tensor:
+        return self.data[index]
+
+
+class TrainingLogger:
+    def __init__(self, backend: str, log_dir: Path, project: Optional[str] = None, entity: Optional[str] = None) -> None:
+        self.backend = backend
+        self.project = project
+        self.entity = entity
+        self.writer = None
+        if backend == "tensorboard" and SummaryWriter is not None:
+            log_dir.mkdir(parents=True, exist_ok=True)
+            self.writer = SummaryWriter(log_dir=str(log_dir))
+        elif backend == "wandb" and wandb is not None:
+            wandb.init(project=project, entity=entity, dir=str(log_dir))
+        else:
+            self.backend = "stdout"
+
+    def log(self, metrics: Mapping[str, float], step: int) -> None:
+        if self.backend == "tensorboard" and self.writer is not None:
+            for key, value in metrics.items():
+                self.writer.add_scalar(key, value, global_step=step)
+        elif self.backend == "wandb" and wandb is not None:
+            wandb.log({**metrics, "step": step})
+        else:
+            formatted = ", ".join(f"{k}={v:.4f}" for k, v in metrics.items())
+            print(f"[step {step}] {formatted}")
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        if self.backend == "tensorboard" and self.writer is not None:
+            self.writer.flush()
+            self.writer.close()
+        elif self.backend == "wandb" and wandb is not None:
+            wandb.finish()
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():  # pragma: no cover - optional GPU path
+        torch.cuda.manual_seed_all(seed)
+
+
+def deep_update(base: MutableMapping[str, Any], new: Mapping[str, Any]) -> MutableMapping[str, Any]:
+    for key, value in new.items():
+        if key in base and isinstance(base[key], MutableMapping) and isinstance(value, Mapping):
+            deep_update(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def load_config(path: Optional[str]) -> Dict[str, Any]:
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    if path is None:
+        return config
+    file = Path(path)
+    if not file.exists():
+        raise FileNotFoundError(f"Config file {path} does not exist.")
+    content = file.read_text()
+    if file.suffix in {".yaml", ".yml"}:
+        if yaml is None:
+            raise RuntimeError("PyYAML is required to load YAML configs.")
+        parsed = yaml.safe_load(content) or {}
+    else:
+        parsed = json.loads(content)
+    if not isinstance(parsed, Mapping):
+        raise ValueError("Configuration file must define a mapping.")
+    deep_update(config, parsed)
+    return config
+
+
+def _split_dataset(dataset: ConformationDataset, train_fraction: float, val_fraction: float, seed: int) -> Tuple[Subset[Tensor], Subset[Tensor], Subset[Tensor]]:
+    generator = torch.Generator().manual_seed(seed)
+    n_total = len(dataset)
+    n_train = int(n_total * train_fraction)
+    n_val = int(n_total * val_fraction)
+    n_test = max(n_total - n_train - n_val, 0)
+    return torch.utils.data.random_split(dataset, [n_train, n_val, n_test], generator=generator)
+
+
+def _prepare_dataloaders(config: Dict[str, Any]) -> Tuple[DataLoader[Tensor], Optional[DataLoader[Tensor]], Optional[DataLoader[Tensor]], int]:
+    dataset_cfg = config["dataset"]
+    path = Path(dataset_cfg["path"])
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Dataset not found at {path}. Generate it with data/generate_synthetic_hexapeptide.py."
+        )
+    array = np.load(path)
+    dataset = ConformationDataset(array)
+    train_set, val_set, test_set = _split_dataset(
+        dataset,
+        train_fraction=float(dataset_cfg.get("train_fraction", 0.7)),
+        val_fraction=float(dataset_cfg.get("val_fraction", 0.15)),
+        seed=int(dataset_cfg.get("seed", 123)),
+    )
+    batch_size = int(config["training"].get("batch_size", 64))
+    train_loader = DataLoader(train_set, batch_size=batch_size, shuffle=True, drop_last=False)
+    val_loader = DataLoader(val_set, batch_size=batch_size, shuffle=False) if len(val_set) > 0 else None
+    test_loader = DataLoader(test_set, batch_size=batch_size, shuffle=False) if len(test_set) > 0 else None
+    n_atoms = dataset.data.shape[1]
+    return train_loader, val_loader, test_loader, n_atoms
+
+
+def _create_model(config: Dict[str, Any], n_atoms: int) -> MolecularVAE:
+    model_cfg = copy.deepcopy(config["model"])
+    model_cfg["n_atoms"] = n_atoms
+    return MolecularVAE(**model_cfg)
+
+
+def _create_topological_loss(config: Dict[str, Any]) -> Optional[TopologicalLoss]:
+    topo_cfg = config.get("topology", {})
+    if not topo_cfg.get("enabled", False):
+        return None
+    return TopologicalLoss(
+        homology_dims=tuple(topo_cfg.get("homology_dims", (1,))),
+        max_edge_length=topo_cfg.get("max_edge_length"),
+        backend=topo_cfg.get("backend", "auto"),
+        update_every=int(topo_cfg.get("update_every", 1)),
+    )
+
+
+def _device_from_config(config: Dict[str, Any]) -> torch.device:
+    training_cfg = config["training"]
+    requested = training_cfg.get("device", "auto")
+    if requested == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(requested)
+
+
+def _save_checkpoint(
+    directory: Path,
+    model: MolecularVAE,
+    optimizer: torch.optim.Optimizer,
+    config: Dict[str, Any],
+    state: TrainState,
+    tag: str,
+) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    checkpoint = {
+        "model_state": model.state_dict(),
+        "optimizer_state": optimizer.state_dict(),
+        "config": config,
+        "epoch": state.epoch,
+        "step": state.step,
+        "best_loss": state.best_loss,
+    }
+    path = directory / f"checkpoint_{tag}.pt"
+    torch.save(checkpoint, path)
+    return path
+
+
+def _load_checkpoint(path: Path, device: torch.device) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Checkpoint {path} does not exist.")
+    return torch.load(path, map_location=device)
+
+
+def train(config: Dict[str, Any], *, resume: Optional[Path] = None) -> Dict[str, Any]:
+    training_cfg = config["training"]
+    set_seed(int(training_cfg.get("seed", 42)))
+
+    device = _device_from_config(config)
+
+    train_loader, val_loader, _, n_atoms = _prepare_dataloaders(config)
+    config["model"]["n_atoms"] = n_atoms
+
+    model = _create_model(config, n_atoms).to(device)
+    optimizer = torch.optim.Adam(
+        model.parameters(),
+        lr=float(training_cfg.get("learning_rate", 1e-3)),
+        weight_decay=float(training_cfg.get("weight_decay", 0.0)),
+    )
+
+    state = TrainState(epoch=0, step=0, best_loss=float("inf"))
+
+    if resume is not None:
+        checkpoint = _load_checkpoint(resume, device)
+        model.load_state_dict(checkpoint["model_state"])
+        optimizer.load_state_dict(checkpoint["optimizer_state"])
+        config = checkpoint.get("config", config)
+        training_cfg = config["training"]
+        state = TrainState(
+            epoch=int(checkpoint.get("epoch", 0)),
+            step=int(checkpoint.get("step", 0)),
+            best_loss=float(checkpoint.get("best_loss", float("inf"))),
+        )
+
+    topo_loss_module = _create_topological_loss(config)
+    topo_weight = float(config.get("topology", {}).get("weight", 1.0))
+    beta = float(training_cfg.get("beta", 1.0))
+    max_steps = training_cfg.get("max_steps")
+    log_every = int(training_cfg.get("log_every", 10))
+    checkpoint_every = int(training_cfg.get("checkpoint_every", 100))
+
+    output_dir = Path(training_cfg.get("output_dir", "runs/vae"))
+    checkpoints_dir = output_dir / "checkpoints"
+    logger = TrainingLogger(
+        backend=config.get("logging", {}).get("backend", "tensorboard"),
+        log_dir=output_dir,
+        project=config.get("logging", {}).get("project"),
+        entity=config.get("logging", {}).get("entity"),
+    )
+
+    history: Dict[str, list[float]] = {"reconstruction": [], "kl": [], "topology": []}
+
+    try:
+        for epoch in range(state.epoch, int(training_cfg.get("epochs", 1))):
+            model.train()
+            for batch in train_loader:
+                batch = batch.to(device)
+                optimizer.zero_grad(set_to_none=True)
+                output = model(batch)
+                constraint_term = model.constraint_loss(output.reconstruction)
+                topo_term = None
+                if topo_loss_module is not None:
+                    topo_term = topo_loss_module(batch.detach(), output.reconstruction.detach(), step=state.step)
+                losses = vae_loss(
+                    output,
+                    batch,
+                    beta=beta,
+                    topo_term=topo_term,
+                    topo_weight=topo_weight,
+                    constraint_term=constraint_term,
+                )
+                losses["loss"].backward()
+                torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+                optimizer.step()
+
+                state.step += 1
+
+                total_loss_value = float(losses["loss"].detach().cpu())
+                history["reconstruction"].append(float(losses["reconstruction"].detach().cpu()))
+                history["kl"].append(float(losses["kl"].detach().cpu()))
+                history["topology"].append(float(losses["topology"].detach().cpu()))
+                state.best_loss = min(state.best_loss, total_loss_value)
+
+                if state.step % log_every == 0:
+                    logger.log(
+                        {
+                            "loss/reconstruction": float(losses["reconstruction"].detach().cpu()),
+                            "loss/kl": float(losses["kl"].detach().cpu()),
+                            "loss/topology": float(losses["topology"].detach().cpu()),
+                            "loss/total": total_loss_value,
+                        },
+                        step=state.step,
+                    )
+
+                if state.step % checkpoint_every == 0:
+                    _save_checkpoint(checkpoints_dir, model, optimizer, config, state, tag=str(state.step))
+
+                if max_steps is not None and state.step >= int(max_steps):
+                    raise StopIteration
+
+            state.epoch = epoch + 1
+            _save_checkpoint(checkpoints_dir, model, optimizer, config, state, tag=f"epoch{state.epoch}")
+    except StopIteration:
+        pass
+    finally:
+        logger.close()
+
+    final_checkpoint = _save_checkpoint(checkpoints_dir, model, optimizer, config, state, tag="final")
+    return {
+        "model": model,
+        "optimizer": optimizer,
+        "config": config,
+        "state": state,
+        "history": history,
+        "checkpoint": final_checkpoint,
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:  # pragma: no cover - thin wrapper
+    parser = argparse.ArgumentParser(description="Train the molecular VAE with topological regularisation.")
+    parser.add_argument("--config", type=str, default=None, help="Path to a YAML or JSON config file.")
+    parser.add_argument("--resume", type=str, default=None, help="Resume training from a checkpoint.")
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> Dict[str, Any]:  # pragma: no cover - CLI wrapper
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    config = load_config(args.config)
+    resume_path = Path(args.resume) if args.resume else None
+    result = train(config, resume=resume_path)
+    return result
+
+
+__all__ = [
+    "ConformationDataset",
+    "TrainingLogger",
+    "TrainState",
+    "DEFAULT_CONFIG",
+    "load_config",
+    "train",
+    "main",
+]

--- a/tests/test_topo_loss.py
+++ b/tests/test_topo_loss.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest import mock
+
+import numpy as np
+
+try:
+    import torch
+except ImportError:  # pragma: no cover - torch optional for tests
+    torch = None  # type: ignore
+
+if torch is not None:
+    from src.models.topo_loss import TopologicalLoss
+    from src.tda.persistence import DiagramBatch
+else:  # pragma: no cover - skip tests when torch unavailable
+    TopologicalLoss = None  # type: ignore
+    DiagramBatch = None  # type: ignore
+
+
+@unittest.skipIf(torch is None, "PyTorch is required for topological loss tests.")
+class TopologicalLossTest(unittest.TestCase):
+    def _diagram(self, value: float = 0.5) -> DiagramBatch:
+        point = np.array([[0.0, value]], dtype=float)
+        return DiagramBatch(diagrams=[{1: point}], homology_dims=(1,))
+
+    def test_caches_loss_between_updates(self) -> None:
+        topo = TopologicalLoss(homology_dims=(1,), update_every=2)
+        real = torch.zeros((1, 2, 3))
+        generated = torch.ones((1, 2, 3))
+
+        diagrams = [self._diagram() for _ in range(6)]
+        with mock.patch(
+            "src.models.topo_loss.compute_persistence_diagrams",
+            side_effect=diagrams,
+        ) as mock_compute, mock.patch(
+            "src.models.topo_loss.wasserstein_distance",
+            return_value=0.5,
+        ) as mock_metric:
+            loss1 = topo(real, generated, step=0)
+            self.assertAlmostEqual(loss1.item(), 0.5, places=6)
+            self.assertEqual(mock_compute.call_count, 2)
+            self.assertEqual(mock_metric.call_count, 1)
+
+            loss2 = topo(real, generated, step=1)
+            self.assertAlmostEqual(loss2.item(), 0.5, places=6)
+            self.assertEqual(mock_compute.call_count, 2)
+
+            loss3 = topo(real, generated, step=2)
+            self.assertAlmostEqual(loss3.item(), 0.5, places=6)
+            self.assertEqual(mock_compute.call_count, 4)
+            self.assertEqual(mock_metric.call_count, 2)
+
+    def test_reference_diagrams_allow_none_real_batch(self) -> None:
+        topo = TopologicalLoss(homology_dims=(1,))
+        topo.set_reference(self._diagram())
+        generated = torch.ones((1, 2, 3))
+
+        with mock.patch(
+            "src.models.topo_loss.compute_persistence_diagrams",
+            return_value=self._diagram(1.0),
+        ) as mock_compute, mock.patch(
+            "src.models.topo_loss.wasserstein_distance",
+            return_value=1.25,
+        ):
+            loss = topo(None, generated, step=0, force=True)
+            self.assertAlmostEqual(loss.item(), 1.25, places=6)
+            mock_compute.assert_called_once()
+            per_dim = topo.last_per_dimension
+            self.assertIsNotNone(per_dim)
+            self.assertAlmostEqual(per_dim[1], 1.25, places=6)
+
+    def test_missing_reference_raises(self) -> None:
+        topo = TopologicalLoss(homology_dims=(1,))
+        generated = torch.ones((1, 2, 3))
+        with self.assertRaises(ValueError):
+            topo(None, generated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_train_eval_workflow.py
+++ b/tests/test_train_eval_workflow.py
@@ -1,0 +1,97 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+
+try:
+    import torch
+except ImportError:  # pragma: no cover
+    torch = None  # type: ignore
+
+from src.tda.persistence import DiagramBatch
+
+if torch is not None:
+    from src.train.train_vae import train
+    from src.train.eval_topology import evaluate
+else:  # pragma: no cover - skip when torch missing
+    train = None  # type: ignore
+    evaluate = None  # type: ignore
+
+
+@unittest.skipIf(torch is None, "PyTorch is required for the training workflow test.")
+class TrainEvalWorkflowTest(unittest.TestCase):
+    def test_train_and_evaluate_with_mocks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data = np.random.randn(12, 4, 3).astype(np.float32)
+            dataset_path = Path(tmpdir) / "toy.npy"
+            np.save(dataset_path, data)
+
+            config = {
+                "dataset": {
+                    "path": str(dataset_path),
+                    "train_fraction": 1.0,
+                    "val_fraction": 0.0,
+                    "test_fraction": 0.0,
+                    "seed": 0,
+                },
+                "model": {
+                    "latent_dim": 2,
+                    "hidden_dims": [8],
+                    "coordinate_scaling": 1.0,
+                },
+                "training": {
+                    "epochs": 1,
+                    "batch_size": 4,
+                    "learning_rate": 1e-3,
+                    "weight_decay": 0.0,
+                    "beta": 1.0,
+                    "max_steps": 3,
+                    "log_every": 1,
+                    "checkpoint_every": 2,
+                    "output_dir": str(Path(tmpdir) / "runs"),
+                    "seed": 0,
+                    "device": "cpu",
+                },
+                "topology": {"enabled": False},
+                "logging": {"backend": "stdout"},
+            }
+
+            result = train(config)
+            self.assertGreater(result["state"].step, 0)
+            self.assertTrue(result["checkpoint"].exists())
+
+            diag_real = DiagramBatch(
+                diagrams=[{0: np.array([[0.0, 0.5]]), 1: np.array([[0.1, 0.6]])}],
+                homology_dims=(0, 1),
+            )
+            diag_gen = DiagramBatch(
+                diagrams=[{0: np.array([[0.0, 0.55]]), 1: np.array([[0.2, 0.7]])}],
+                homology_dims=(0, 1),
+            )
+
+            with mock.patch(
+                "src.train.eval_topology.compute_persistence_diagrams",
+                side_effect=[diag_real, diag_gen],
+            ), mock.patch(
+                "src.train.eval_topology.wasserstein_distance",
+                return_value=0.3,
+            ), mock.patch(
+                "src.train.eval_topology.bottleneck_distance",
+                return_value=0.2,
+            ):
+                eval_result = evaluate(
+                    result["checkpoint"],
+                    num_samples=5,
+                    output_dir=Path(tmpdir) / "eval",
+                    device="cpu",
+                )
+
+            self.assertIn("metrics", eval_result)
+            metrics_path = Path(tmpdir) / "eval" / "metrics.json"
+            self.assertTrue(metrics_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vae.py
+++ b/tests/test_vae.py
@@ -1,0 +1,59 @@
+import unittest
+
+try:
+    import torch
+except ImportError:  # pragma: no cover
+    torch = None  # type: ignore
+
+if torch is not None:
+    from src.models.vae import MolecularVAE, vae_loss
+else:  # pragma: no cover - skip when torch missing
+    MolecularVAE = None  # type: ignore
+    vae_loss = None  # type: ignore
+
+
+@unittest.skipIf(torch is None, "PyTorch is required for VAE tests.")
+class MolecularVAETest(unittest.TestCase):
+    def test_forward_shapes_and_sampling(self) -> None:
+        model = MolecularVAE(n_atoms=4, latent_dim=3, hidden_dims=(16, 8))
+        batch = torch.randn(2, 4, 3)
+        output = model(batch)
+        self.assertEqual(output.reconstruction.shape, batch.shape)
+        self.assertEqual(output.mean.shape, (2, 3))
+        self.assertEqual(output.logvar.shape, (2, 3))
+
+        samples = model.sample(5)
+        self.assertEqual(samples.shape, (5, 4, 3))
+
+    def test_constraint_loss_matches_targets(self) -> None:
+        model = MolecularVAE(
+            n_atoms=4,
+            latent_dim=2,
+            hidden_dims=(8,),
+            enforce_constraints=True,
+            bond_indices=[(0, 1)],
+            target_bond_lengths=[1.0],
+        )
+        coords = torch.zeros((2, 4, 3))
+        coords[:, 1, 0] = 1.0
+        self.assertAlmostEqual(model.constraint_loss(coords).item(), 0.0, places=6)
+
+        coords[:, 1, 0] = 2.0
+        loss = model.constraint_loss(coords)
+        self.assertGreater(loss.item(), 0.0)
+
+    def test_vae_loss_outputs(self) -> None:
+        model = MolecularVAE(n_atoms=3, latent_dim=2, hidden_dims=(8,))
+        batch = torch.randn(4, 3, 3)
+        output = model(batch)
+        losses = vae_loss(output, batch, beta=0.5)
+        self.assertIn("loss", losses)
+        self.assertIn("reconstruction", losses)
+        self.assertIn("kl", losses)
+        losses["loss"].backward()
+        grads = [param.grad for param in model.parameters()]
+        self.assertTrue(any(g is not None for g in grads))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a topological Wasserstein loss module with caching and reference support
- implement a molecular VAE architecture plus constraint-aware loss helpers
- provide training and evaluation entrypoints with logging, checkpointing, and mocked workflow tests

## Testing
- python -m unittest  *(skipped: PyTorch not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e49cf4dc84832f870466a6b634857a