### PR TITLE
Compute topology in dihedral space

### DIFF
--- a/scripts/phase1/README.md
+++ b/scripts/phase1/README.md
@@ -40,11 +40,14 @@ After generating a dataset (either MD or MC), run:
 ```
 python scripts/phase1/validate_dataset.py \
     --dataset data/cyclo_ala6_md.npy \
+    --topology data/templates/cyclo_ala6_initial.pdb \
     --output-dir results/phase1
 ```
 
 This produces the figures and summary statistics required for Figure 1 and the
-paper narrative:
+paper narrative. The persistence calculations now operate on backbone dihedral
+angles (φ/ψ) to capture cyclic transitions that are invisible in Cartesian
+space:
 
 - `ground_truth_pd.png` / `ground_truth_barcode.png`
 - `rmsd_distribution.png`, `rg_distribution.png`
@@ -58,5 +61,7 @@ All outputs land in `results/phase1/` by default.
 - Install dependencies via `conda env create -f environment.yml` before running.
 - For HPC clusters, wrap the MD script in an sbatch file; the script is
   thread-safe and can be parallelised across replicas.
+- The validation script requires the same topology (PDB) used for data
+  generation so it can compute φ/ψ dihedrals prior to persistence analysis.
 - Validate a small subset first using `--max-samples 500` when running the
   validation script.

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,5 @@
+"""Data loading and featurization utilities."""
+
+from .featurize import DihedralSpecification, extract_dihedrals
+
+__all__ = ["DihedralSpecification", "extract_dihedrals"]

--- a/src/data/featurize.py
+++ b/src/data/featurize.py
@@ -1,0 +1,174 @@
+"""Feature extraction utilities for molecular conformations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+try:  # Optional dependency used when topology information is available
+    import mdtraj as md
+except Exception:  # pragma: no cover - mdtraj is optional at runtime
+    md = None  # type: ignore
+
+_TWO_PI = 2.0 * np.pi
+
+
+@dataclass(frozen=True)
+class DihedralSpecification:
+    """Specification of a single dihedral in terms of atom indices."""
+
+    atom_indices: Tuple[int, int, int, int]
+    label: str | None = None
+
+
+def _normalize_angles(angles: np.ndarray, wrap: bool) -> np.ndarray:
+    if not wrap:
+        return angles
+    return np.mod(angles + _TWO_PI, _TWO_PI)
+
+
+def _batch_dihedral(points: np.ndarray) -> np.ndarray:
+    """Compute dihedral angles for a batch of 4-point fragments."""
+
+    p0 = points[:, 0, :]
+    p1 = points[:, 1, :]
+    p2 = points[:, 2, :]
+    p3 = points[:, 3, :]
+
+    b0 = p1 - p0
+    b1 = p2 - p1
+    b2 = p3 - p2
+
+    b1_norm = np.linalg.norm(b1, axis=1, keepdims=True)
+    # Prevent division by zero by adding an epsilon; degenerate torsions will
+    # produce zero angles after normalization.
+    b1_unit = np.divide(b1, np.where(b1_norm == 0.0, 1.0, b1_norm))
+
+    v = b0 - (np.sum(b0 * b1_unit, axis=1, keepdims=True) * b1_unit)
+    w = b2 - (np.sum(b2 * b1_unit, axis=1, keepdims=True) * b1_unit)
+
+    x = np.sum(v * w, axis=1)
+    y = np.sum(np.cross(b1_unit, v), w, axis=1)
+    angles = np.arctan2(y, x)
+    return angles
+
+
+def _phi_psi_indices(
+    topology: "md.Topology",
+    residue_indices: Optional[Sequence[int]] = None,
+    cyclic: bool = True,
+) -> List[DihedralSpecification]:
+    residues = list(topology.residues)
+    if residue_indices is None:
+        residue_indices = [res.index for res in residues]
+    lookup = {(atom.residue.index, atom.name.strip()): atom.index for atom in topology.atoms}
+    n_res = len(residues)
+
+    def _get_index(res_idx: int, atom_name: str) -> int:
+        key = (res_idx, atom_name)
+        if key not in lookup:
+            raise KeyError(f"Atom {atom_name} not found in residue {res_idx}.")
+        return lookup[key]
+
+    specs: List[DihedralSpecification] = []
+    for res_idx in residue_indices:
+        prev_idx = (res_idx - 1) % n_res if cyclic else res_idx - 1
+        next_idx = (res_idx + 1) % n_res if cyclic else res_idx + 1
+
+        try:
+            if prev_idx >= 0:
+                phi = (
+                    _get_index(prev_idx, "C"),
+                    _get_index(res_idx, "N"),
+                    _get_index(res_idx, "CA"),
+                    _get_index(res_idx, "C"),
+                )
+                specs.append(DihedralSpecification(phi, label=f"phi_{res_idx}"))
+        except KeyError:
+            pass
+
+        try:
+            if next_idx < n_res or cyclic:
+                psi = (
+                    _get_index(res_idx, "N"),
+                    _get_index(res_idx, "CA"),
+                    _get_index(res_idx, "C"),
+                    _get_index(next_idx % n_res, "N"),
+                )
+                specs.append(DihedralSpecification(psi, label=f"psi_{res_idx}"))
+        except KeyError:
+            pass
+
+    return specs
+
+
+def extract_dihedrals(
+    coords: np.ndarray,
+    topology: "md.Topology" | None = None,
+    *,
+    residue_indices: Optional[Sequence[int]] = None,
+    custom_dihedrals: Optional[Iterable[Sequence[int]]] = None,
+    wrap: bool = True,
+) -> np.ndarray:
+    """Extract backbone dihedral angles from molecular conformations.
+
+    Parameters
+    ----------
+    coords:
+        Array of shape ``(n_samples, n_atoms, 3)`` containing Cartesian
+        coordinates.
+    topology:
+        Optional MDTraj topology describing atom ordering. Required when
+        ``custom_dihedrals`` is not provided.
+    residue_indices:
+        Optional iterable of residue indices for which phi/psi dihedrals should
+        be computed. Defaults to all residues in ``topology``.
+    custom_dihedrals:
+        Optional explicit list of 4-tuples of atom indices specifying which
+        dihedrals to compute. When supplied, this overrides automatic phi/psi
+        inference and does not require a topology object.
+    wrap:
+        If ``True`` (default), returned angles are wrapped into the interval
+        ``[0, 2π)``. Otherwise raw ``(-π, π]`` radians are returned.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape ``(n_samples, n_dihedrals)`` containing dihedral angles
+        in radians.
+    """
+
+    array = np.asarray(coords, dtype=float)
+    if array.ndim != 3 or array.shape[-1] != 3:
+        raise ValueError(
+            "coords must have shape (n_samples, n_atoms, 3); received "
+            f"{array.shape}."
+        )
+
+    n_samples = array.shape[0]
+
+    if custom_dihedrals is not None:
+        specs = [DihedralSpecification(tuple(map(int, dihedral))) for dihedral in custom_dihedrals]
+    else:
+        if topology is None:
+            raise ValueError("topology must be provided when custom_dihedrals is None.")
+        if md is None:  # pragma: no cover - happens only when mdtraj missing
+            raise ImportError("mdtraj is required to infer phi/psi dihedrals from topology.")
+        specs = _phi_psi_indices(topology, residue_indices=residue_indices)
+        if not specs:
+            raise ValueError("No dihedral definitions could be constructed from the provided topology.")
+
+    angles = np.empty((n_samples, len(specs)), dtype=float)
+    for column, spec in enumerate(specs):
+        atom_indices = np.asarray(spec.atom_indices, dtype=int)
+        fragment = array[:, atom_indices, :]
+        angles[:, column] = _batch_dihedral(fragment)
+
+    return _normalize_angles(angles, wrap=wrap)
+
+
+__all__ = [
+    "DihedralSpecification",
+    "extract_dihedrals",
+]

--- a/tests/test_featurize.py
+++ b/tests/test_featurize.py
@@ -1,0 +1,58 @@
+import math
+import unittest
+
+import numpy as np
+
+from src.data import extract_dihedrals
+
+
+class ExtractDihedralsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Two simple fragments where the final atom is displaced to generate a
+        # non-zero torsion. Coordinates are chosen so the first frame is planar
+        # (angle = 0) and the second is rotated out of plane.
+        self.coords = np.array(
+            [
+                [
+                    [0.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [1.0, 1.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                ],
+                [
+                    [0.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [1.0, 1.0, 0.0],
+                    [0.0, 1.0, 1.0],
+                ],
+            ],
+            dtype=float,
+        )
+        self.indices = [(0, 1, 2, 3)]
+
+    def test_custom_dihedrals_shape_and_range(self) -> None:
+        angles = extract_dihedrals(self.coords, custom_dihedrals=self.indices)
+        self.assertEqual(angles.shape, (2, 1))
+        self.assertTrue(np.all(angles >= 0.0))
+        self.assertTrue(np.all(angles < 2.0 * math.pi))
+
+    def test_wrap_false_preserves_signed_angle(self) -> None:
+        wrapped = extract_dihedrals(self.coords, custom_dihedrals=self.indices, wrap=True)
+        raw = extract_dihedrals(self.coords, custom_dihedrals=self.indices, wrap=False)
+        self.assertAlmostEqual(float(wrapped[0, 0]), 0.0, places=6)
+        self.assertAlmostEqual(float(raw[0, 0]), 0.0, places=6)
+        # Second frame should be negative before wrapping because of the right-hand rule
+        self.assertLess(raw[1, 0], 0.0)
+        self.assertAlmostEqual(
+            float(wrapped[1, 0]),
+            (raw[1, 0] + 2.0 * math.pi) % (2.0 * math.pi),
+            places=6,
+        )
+
+    def test_missing_topology_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            extract_dihedrals(self.coords, topology=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,44 @@
+import math
+import unittest
+from unittest import mock
+
+import numpy as np
+
+from src.tda.persistence import compute_persistence_diagrams
+
+
+class PersistenceGeometryTest(unittest.TestCase):
+    def test_dihedral_geometry_uses_torus_distance(self) -> None:
+        points = np.array([
+            [0.0, 0.0],
+            [2.0 * math.pi - 0.2, 0.2],
+        ])
+
+        fake_diag = {0: np.empty((0, 2))}
+        with mock.patch("src.tda.persistence._compute_with_gudhi", return_value=fake_diag) as mock_gudhi, mock.patch(
+            "src.tda.persistence._compute_with_ripser"
+        ) as mock_ripser:
+            diagrams = compute_persistence_diagrams(
+                points[None, ...],
+                homology_dims=(0,),
+                backend="gudhi",
+                center=False,
+                geometry="dihedral",
+            )
+            self.assertEqual(len(diagrams.diagrams), 1)
+            # Ensure ripser fallback wasn't used when GUDHI path succeeds
+            mock_ripser.assert_not_called()
+
+        # GUDHI helper should have received a torus-aware distance matrix where the
+        # two points are ~0.2828 apart instead of ~6.18 in Euclidean space.
+        _, _, _, dist_matrix = mock_gudhi.call_args[0]
+        self.assertAlmostEqual(dist_matrix[0, 1], math.sqrt(0.2**2 + 0.2**2), places=6)
+        self.assertAlmostEqual(dist_matrix[1, 0], dist_matrix[0, 1], places=6)
+
+    def test_cartesian_geometry_requires_three_dims(self) -> None:
+        with self.assertRaises(ValueError):
+            compute_persistence_diagrams(np.zeros((1, 4, 2)), geometry="cartesian")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add dihedral extraction utilities so cyclic peptide conformations can be mapped to a 12D torus feature space
- extend persistence computation to support periodic dihedral geometry and reuse it inside the Phase 1 validation workflow
- update the validation docs/scripts and add unit tests covering the new featurisation and torus-distance handling

## Testing
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'numpy' in this execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ba98b584832f8c9a4ffbccbe875a